### PR TITLE
Removed the Requirement to Train Data to split

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     parser.add_argument("--split", action="store_true")
     args = parser.parse_args()
 
-    if args.split and "train" in args.mode:
+    if args.split:
         split_data()
 
     if "train" in args.mode:


### PR DESCRIPTION
Validating alone doesnt work elsewise.
The working validation command is:
`python main.py --split --mode val`